### PR TITLE
修复安卓下使用新版本sdk，未实现popupEventDecideShow接口造成的闪退问题

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    compileOnly "com.growingio.android:vds-android-agent:track-2.8.4@aar"
-    compileOnly 'com.growingio.android:gtouch:1.0.0'
+    compileOnly "com.growingio.android:vds-android-agent:track-2.8.23"
+    compileOnly 'com.growingio.android:gtouch:1.4.6'
 }
 

--- a/android/src/main/java/com/growingio/android/sdk/gtouch/rn/RNGrowingTouchModule.java
+++ b/android/src/main/java/com/growingio/android/sdk/gtouch/rn/RNGrowingTouchModule.java
@@ -15,6 +15,8 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.growingio.android.sdk.common.log.Logger;
 import com.growingio.android.sdk.gtouch.GTouchManager;
 import com.growingio.android.sdk.gtouch.GrowingTouch;
+import com.growingio.android.sdk.gtouch.data.entity.PopupWindowEvent;
+import com.growingio.android.sdk.gtouch.event.EventPopupDecisionAction;
 import com.growingio.android.sdk.gtouch.listener.EventPopupListener;
 
 public class RNGrowingTouchModule extends ReactContextBaseJavaModule {

--- a/android/src/main/java/com/growingio/android/sdk/gtouch/rn/RNGrowingTouchModule.java
+++ b/android/src/main/java/com/growingio/android/sdk/gtouch/rn/RNGrowingTouchModule.java
@@ -145,6 +145,12 @@ public class RNGrowingTouchModule extends ReactContextBaseJavaModule {
             data.putString("eventType", eventType);
             mEventEmitter.emit(GTOUCH_EVENT_REMINDER, data);
         }
+        
+        @Override
+        public boolean popupEventDecideShow(PopupWindowEvent popupWindowEvent, EventPopupDecisionAction eventPopupDecisionAction) {
+
+            return false;
+        }
     }
 
 }

--- a/android/src/main/java/com/growingio/android/sdk/gtouch/rn/RNGrowingTouchModule.java
+++ b/android/src/main/java/com/growingio/android/sdk/gtouch/rn/RNGrowingTouchModule.java
@@ -145,10 +145,9 @@ public class RNGrowingTouchModule extends ReactContextBaseJavaModule {
             data.putString("eventType", eventType);
             mEventEmitter.emit(GTOUCH_EVENT_REMINDER, data);
         }
-        
+
         @Override
         public boolean popupEventDecideShow(PopupWindowEvent popupWindowEvent, EventPopupDecisionAction eventPopupDecisionAction) {
-
             return false;
         }
     }

--- a/ios/RNGrowingTouch.m
+++ b/ios/RNGrowingTouch.m
@@ -156,5 +156,17 @@ RCT_EXPORT_METHOD(setEventPopupListener) {
                                                            @"eventType": eventType}];
     }
 }
+/**
+ * 触达弹窗消费时（待展示时）
+ * @param popup 待展示的弹窗数据
+ *
+ * @param action 弹窗绑定的操作行为
+ *
+ * @return true：自定义展示该弹窗，触达SDK不在处理；false：由触达来展示该弹窗，
+ * @discussion 在 popup.rule.target 数据中可以取出配置的 target 数据，比如一张图片的链接或其他参数，进行自定义的弹窗展示
+ */
+- (BOOL)popupEventDecideShowPopupView:(GrowingPopupWindowEvent *)popup decisionAction:(GrowingEventPopupDecisionAction *)action {
+    return NO;
+}
 @end
 

--- a/ios/RNGrowingTouch.m
+++ b/ios/RNGrowingTouch.m
@@ -156,17 +156,5 @@ RCT_EXPORT_METHOD(setEventPopupListener) {
                                                            @"eventType": eventType}];
     }
 }
-/**
- * 触达弹窗消费时（待展示时）
- * @param popup 待展示的弹窗数据
- *
- * @param action 弹窗绑定的操作行为
- *
- * @return true：自定义展示该弹窗，触达SDK不在处理；false：由触达来展示该弹窗，
- * @discussion 在 popup.rule.target 数据中可以取出配置的 target 数据，比如一张图片的链接或其他参数，进行自定义的弹窗展示
- */
-- (BOOL)popupEventDecideShowPopupView:(GrowingPopupWindowEvent *)popup decisionAction:(GrowingEventPopupDecisionAction *)action {
-    return NO;
-}
 @end
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-growing-touch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Growing Touch for React Native",
   "main": "GrowingTouch.js",
   "scripts": {


### PR DESCRIPTION
使用新版安卓touch sdk 比如1.4.6、App在打开的状态下、扫码测试弹窗、拉起app会直接导致App闪退。
本次更改以下内容：
1、sdk版本更新至 gtouch:1.4.6、vds-android-agent:track-2.8.23
2、增加EventPopupListener接口的popupEventDecideShow实现、否则会在热启动时崩溃